### PR TITLE
Allow overriding `pg_config`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ PG_CFLAGS = $(BSON_INCLUDES) $(LOCAL_CFLAGS)
 SHLIB_LINK = $(BSON_SHLIB)
 
 # for postgres build
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
-


### PR DESCRIPTION
Allow user to override the pg_config using in Makefile. Very useful when there are multiple postgres installed on same host (often in dev environments). For example:

```
PG_CONFIG=/path/to/my/pg_config make install
```

Basically same as [pg_cron](https://github.com/citusdata/pg_cron/blob/a8cb0e0b5018cf82e5a90728a91d04fb79594642/Makefile#L22), [pgvector](https://github.com/pgvector/pgvector/blob/69a2ce0d432f45f24186ce7ef1683ab9af5329df/Makefile#L46), [pg_partman](https://github.com/pgpartman/pg_partman/blob/f1c75838652487bcfdbdacf2631bf43eb318320a/Makefile#L5)